### PR TITLE
Updates branding to MOTA

### DIFF
--- a/src/routes/(portal)/keys/+page.svelte
+++ b/src/routes/(portal)/keys/+page.svelte
@@ -5,7 +5,7 @@
 <div class="max-w-4xl mx-auto p-6">
 	<h1 class="text-3xl font-bold mb-4">Key Registry</h1>
 	<p class="mb-4">
-		Welcome to the Key Registry. Here you can find all types of keys used by CorePort.
+		Welcome to the Key Registry. Here you can find all types of keys used by MOTA.
 	</p>
 
 	<h2 class="text-xl font-bold mb-2">Public Key Types</h2>


### PR DESCRIPTION
Replaces references to "CorePort" with "MOTA" in the key registry page.

This change reflects the updated branding for the application.