### PR TITLE
Adds stub for typesafe-i18n support

### DIFF
--- a/src/i18n/i18n-util.async.ts
+++ b/src/i18n/i18n-util.async.ts
@@ -1,0 +1,21 @@
+// This is a stub file for optional typesafe-i18n support
+// When typesafe-i18n is properly set up, this file will be replaced
+// with the generated i18n-util.async.ts file
+
+// Stub types for when typesafe-i18n is not set up
+type Locales = string;
+type Translations = Record<string, any>;
+
+// Stub implementation - does nothing
+// This will be replaced by the real implementation when typesafe-i18n is set up
+export const importLocaleAsync = async (locale: Locales): Promise<Translations> => {
+	return {};
+};
+
+export const loadLocaleAsync = async (locale: Locales): Promise<void> => {};
+
+export const loadAllLocalesAsync = (): Promise<void[]> => {
+	return Promise.resolve([]);
+};
+
+export const loadFormatters = (locale: Locales): void => {};


### PR DESCRIPTION
Introduces a stub file for optional typesafe-i18n integration.

This file provides placeholder types and a no-op implementation for i18n functionalities when typesafe-i18n is not yet set up, preventing errors and allowing the application to run without it. It will be replaced with the generated file when typesafe-i18n is properly configured.